### PR TITLE
feat: adiciona suporte e CAPTURA a números inteiros e ponto flutuante no lexer

### DIFF
--- a/src/lexerC.l
+++ b/src/lexerC.l
@@ -56,11 +56,14 @@
 "'"         { return ASPASSIMPLES;}
 
 
-[0-9]+"."[0-9]+ { return NUM;}
+([0-9]+\.[0-9]*|\.[0-9]+) {             // Captura valores ponto flutuante
+    yylval.floatValue = atof(yytext);   // floatValue tipo float
+    return FLOAT_NUM;
+}
 
 [0-9]+ {
     yylval.intValue = atoi(yytext);
-    return NUM;
+    return INT_NUM;
 }
 
 

--- a/src/parserC.y
+++ b/src/parserC.y
@@ -10,10 +10,13 @@ void yyerror(const char *s);
 %}
 
 %union{
-    int intValue;
+// onde é armazenada o valor capturado do lexer
+    int intValue;       
+    float floatValue;
 }
 
-%token <intValue> NUM
+%token <intValue> INT_NUM
+%token <floatValue> FLOAT_NUM
 
 
 %token IF ELSE INT ID FLOAT CHAR FOR
@@ -32,24 +35,26 @@ void yyerror(const char *s);
 %left PLUS MINUS
 %left MULT DIV
 
-%type <intValue> expressao
+// define o tipo de dado usados na expressões
+%type <intValue> expressao    
+%type <floatValue> expressao_f
 
 
 %%
 programa:
     lista
-;
+    ;
 
 lista:
     lista elemento
     | elemento
-;
+    ;
 
 elemento:
     declaracao
     | atribuicao
     | comando
-;
+    ;
 
 
 declaracao:
@@ -58,30 +63,41 @@ declaracao:
     | CHAR ID PONTO_VIRGULA
     ;
 
-    
+
 atribuicao:
-    INT ID EQUAL NUM PONTO_VIRGULA
-    | FLOAT ID EQUAL NUM PONTO_VIRGULA
+    INT ID EQUAL expressao PONTO_VIRGULA
+    | FLOAT ID EQUAL expressao_f PONTO_VIRGULA 
     | CHAR ID EQUAL ASPASSIMPLES ID ASPASSIMPLES PONTO_VIRGULA
     ;
 
-
 comando:
-    expressao PONTO_VIRGULA { printf("%d\n", $1); }
+    expressao_f PONTO_VIRGULA       { printf("%f\n", $1); }
+    | expressao PONTO_VIRGULA       { printf("%d\n", $1); }
     | IF OPEN_PAREN expressao CLOSE_PAREN comando
+    | IF OPEN_PAREN expressao_f CLOSE_PAREN comando
     | ID EQUAL expressao PONTO_VIRGULA
+    | ID EQUAL expressao_f PONTO_VIRGULA
     ;
 
 expressao:
-      expressao PLUS expressao          { $$ = $1 + $3; }
+    expressao PLUS expressao            { $$ = $1 + $3; }
     | expressao MINUS expressao         { $$ = $1 - $3; }
     | expressao MULT expressao          { $$ = $1 * $3; }
     | expressao DIV expressao           { $$ = $1 / $3; }
     | OPEN_PAREN expressao CLOSE_PAREN  { $$ = $2; }
-    | NUM                               { $$ = $1; }
+    | INT_NUM                           { $$ = $1; }
     ;
 
-%% 
+expressao_f:
+    expressao_f PLUS expressao_f            { $$ = $1 + $3; }
+    | expressao_f MINUS expressao_f         { $$ = $1 - $3; }
+    | expressao_f MULT expressao_f          { $$ = $1 * $3; }
+    | expressao_f DIV expressao_f           { $$ = $1 / $3; }
+    | OPEN_PAREN expressao_f CLOSE_PAREN    { $$ = $2; }
+    | FLOAT_NUM                             { $$ = $1; }
+    ;
+
+%%
 
 int main(){
     return yyparse();


### PR DESCRIPTION
Adicionei o: |\.[0-9]+)
Para que fosse possível dar suporte a entradas como :    .5  ,    .95
Tive que criar dois NUM, um para o int e outro para float;
E também tive que criar outra (expressao:) no parser, pois suportava apenas intValue, então dupliquei com nome expressao_f, esta sendo tipo floatValue.
 
 