### PR TITLE
adiciona resolução da issue de otimização

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1,7 +1,10 @@
 #include "ast.h"
+#include "semantic.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+extern int yylineno;
 
 /* Aloca e zera um nó — evita campos com lixo de memória */
 static NoAST *alocarNo(void) {
@@ -54,20 +57,98 @@ NoAST *criarNoId(char *nome) {
    por isso adiamos a inferência — o nó fica T_INT por padrão e a semântica
    corrige depois via analisarSemantica(). */
 NoAST *criarNoOp(char operador, NoAST *esq, NoAST *dir) {
-    NoAST *novo = alocarNo();
-    novo->operador  = operador;
-    novo->esquerda  = esq;
-    novo->direita   = dir;
 
-    /* Para ++/--, o nó carrega o operador 'I'/'D' diretamente.
-       O tipo é o do filho esquerdo (ou INT por padrão). */
+    /* ── 1. int × int ── */
+    if (esq->operador == 'n' && dir->operador == 'n'
+        && esq->tipo == T_INT && dir->tipo == T_INT) {
+
+        int a = esq->valor.i, b = dir->valor.i;
+
+        switch (operador) {
+            case '+': return criarNoInt(a + b);
+            case '-': return criarNoInt(a - b);
+            case '*': return criarNoInt(a * b);
+            case '/':
+                if (b == 0) { 
+                    erroSemantico(ERR_DIVISAO_POR_ZERO, yylineno); 
+                    return criarNoInt(0); 
+                }
+                return criarNoInt(a / b);
+            case '%': return criarNoInt(a % b);
+            case '<': return criarNoBool(a <  b);
+            case '>': return criarNoBool(a >  b);
+            case 'e': return criarNoBool(a == b);
+            case '!': return criarNoBool(a != b);
+            case 'L': return criarNoBool(a <= b);
+            case 'G': return criarNoBool(a >= b);
+        }
+    }
+
+    /* ── 2. float × float ── */
+    else if (esq->operador == 'n' && dir->operador == 'n'
+             && esq->tipo == T_FLOAT && dir->tipo == T_FLOAT) {
+
+        float a = esq->valor.f, b = dir->valor.f;
+
+        switch (operador) {
+            case '+': return criarNoFloat(a + b);
+            case '-': return criarNoFloat(a - b);
+            case '*': return criarNoFloat(a * b);
+            case '/':
+                if (b == 0) { 
+                    erroSemantico(ERR_DIVISAO_POR_ZERO, yylineno); 
+                    return criarNoFloat(0);
+                }
+                return criarNoFloat(a / b);
+            case '<': return criarNoBool(a <  b);
+            case '>': return criarNoBool(a >  b);
+            case 'e': return criarNoBool(a == b);
+            case '!': return criarNoBool(a != b);
+            case 'L': return criarNoBool(a <= b);
+            case 'G': return criarNoBool(a >= b);
+        }
+    }
+
+    /* ── 3. misto int+float (promoção para float) ── */
+    else if (esq->operador == 'n' && dir->operador == 'n'
+             && (esq->tipo == T_FLOAT || dir->tipo == T_FLOAT)
+             && (esq->tipo == T_INT   || esq->tipo == T_FLOAT)
+             && (dir->tipo == T_INT   || dir->tipo == T_FLOAT)) {
+
+        float a = (esq->tipo == T_FLOAT) ? esq->valor.f : (float)esq->valor.i;
+        float b = (dir->tipo == T_FLOAT) ? dir->valor.f : (float)dir->valor.i;
+
+        switch (operador) {
+            case '+': return criarNoFloat(a + b);
+            case '-': return criarNoFloat(a - b);
+            case '*': return criarNoFloat(a * b);
+            case '/':
+                if (b == 0) { 
+                    erroSemantico(ERR_DIVISAO_POR_ZERO, yylineno); 
+                    return criarNoFloat(0.0f);
+                }
+                return criarNoFloat(a / b);
+            case '<': return criarNoBool(a <  b);
+            case '>': return criarNoBool(a >  b);
+            case 'e': return criarNoBool(a == b);
+            case '!': return criarNoBool(a != b);
+            case 'L': return criarNoBool(a <= b);
+            case 'G': return criarNoBool(a >= b);
+        }
+    }
+
+    /* ── 4. ao menos um operando não é literal → nó binário normal ── */
+    NoAST *novo = alocarNo();
+    novo->operador = operador;
+    novo->esquerda = esq;
+    novo->direita  = dir;
+
     if (operador == 'I' || operador == 'D') {
         novo->tipo = (esq && esq->operador == 'n' && esq->tipo == T_FLOAT)
                      ? T_FLOAT : T_INT;
         return novo;
     }
 
-    /* Inferência segura: só usa tipo se o nó é literal */
     Tipo te = (esq && esq->operador == 'n') ? esq->tipo : T_INT;
     Tipo td = (dir && dir->operador == 'n') ? dir->tipo : T_INT;
     novo->tipo = (te == T_FLOAT || td == T_FLOAT) ? T_FLOAT : T_INT;

--- a/src/semantic.c
+++ b/src/semantic.c
@@ -8,6 +8,13 @@
 
 static int numErros = 0;
 
+void erroSemantico(int codigoErro, int linha) {
+    numErros++;
+    if (codigoErro == ERR_DIVISAO_POR_ZERO) {
+        printf("Erro Semantico: divisao por zero na linha %d.\n", linha);
+    }
+}
+
 int errosSemanticos(void) { return numErros; }
 
 static const char *tipoStr(Tipo t) {

--- a/src/semantic.h
+++ b/src/semantic.h
@@ -3,6 +3,7 @@
 
 #include "ast.h"
 
+void erroSemantico(int codigoErro, int linha);
 void analisarSemantica(NoAST *raiz);
 int errosSemanticos(void);
 

--- a/src/tipos.h
+++ b/src/tipos.h
@@ -2,6 +2,10 @@
 #define TIPOS_H
 
 typedef enum {
+    ERR_DIVISAO_POR_ZERO
+} CodigoErro;
+
+typedef enum {
     T_INT,
     T_FLOAT,
     T_CHAR,


### PR DESCRIPTION
Este Pull Request resolve a issue #30, implementando a otimização de Constant Folding (colapso de constantes) diretamente na construção da Árvore Sintática Abstrata (AST) dentro do arquivo ast.c.

Com essa alteração, expressões compostas puramente por literais numéricos (como 2 + 3 * 4) passam a ser resolvidas e calculadas em tempo de compilação, reduzindo drasticamente o número de instruções e variáveis temporárias geradas no Código Intermediário (TAC).

🛠️ Alterações Realizadas
1. src/ast.c
Modificação da função criarNoOp para interceptar operações cujos filhos esquerdo e direito sejam nós literais (operador == 'n').

Implementação do cálculo estático para inteiros (T_INT) e floats (T_FLOAT).

Adicionada a promoção automática de tipos (coerção de int para float) em operações mistas.

Adicionado tratamento preventivo para divisão por zero literal, emitindo o erro semântico correto antes de interromper a operação inválida.

2. src/semantic.h & src/semantic.c
Criação de um sistema unificado e limpo para tratamento de erros através da nova função erroSemantico(CodigoErro codigo, int linha).

Centralização do contador de erros (numErros) garantindo consistência no pipeline do compilador.

Definição do enum CodigoErro para categorizar o ERR_DIVISAO_POR_ZERO.

📊 Impacto no Código Intermediário (TAC)
Antes da otimização:

C
// Entrada: int x = 2 + 3 * 4;
t1 = 3
t2 = 4
t3 = t1 * t2
t4 = 2
t5 = t4 + t3
x  = t5          // 5 temporários e instruções desnecessárias
Depois da otimização (Comportamento Atual):

C
// Entrada: int x = 2 + 3 * 4;
x = 14          // Resolvido diretamente na AST!
🧪 Critérios de Aceitação Validados
[x] Operações inteiras (+, -, *, /, %) entre literais são colapsadas em um único nó.

[x] Operações com float aplicam a mesma lógica usando valor.f.

[x] Operações relacionais entre literais (ex: 2 < 5) são avaliadas estaticamente e retornam um nó T_BOOL.

[x] Expressões aninhadas complexas (ex: ((1+2)*(3+4))) são colapsadas por completo de forma recursiva.

[x] Divisão por zero literal emite o erro ERR_DIVISAO_POR_ZERO capturando a linha exata do analisador léxico (yylineno).

[x] Expressões contendo variáveis (ex: x + 1) permanecem intocadas para avaliação em tempo de execução.

🔗 Issues Relacionadas
Closes #30